### PR TITLE
Feature/Re-organize Dependencies and enable Juni4 & Junit5 execution togeter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <wiremock.version>2.35.0</wiremock.version>
     <testcontainers.version>1.18.0</testcontainers.version>
     <junit.version>5.9.2</junit.version>
+    <assertj.version>3.24.2</assertj.version>
     <project.scm.id>github</project.scm.id>
   </properties>
 
@@ -33,6 +34,20 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-bom</artifactId>
+        <version>${assertj.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -40,12 +55,25 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,18 +21,18 @@
     <wiremock.version>2.35.0</wiremock.version>
     <testcontainers.version>1.18.0</testcontainers.version>
     <junit.version>5.9.2</junit.version>
-     <project.scm.id>github</project.scm.id>  
+    <project.scm.id>github</project.scm.id>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-bom</artifactId>
-            <version>${testcontainers.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -124,7 +124,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
@@ -146,14 +146,14 @@
       </releases>
     </repository>
   </repositories>
-  
+
   <scm>
     <connection>scm:git:git://github.com/wiremock/wiremock-testcontainers-java.git</connection>
     <developerConnection>scm:git:https://github.com/wiremock/wiremock-testcontainers-java.git</developerConnection>
     <url>https://github.com/wiremock/wiremock-testcontainers-java</url>
     <tag>${scmTag}</tag>
   </scm>
-         
+
   <distributionManagement>
     <repository>
       <id>github</id>


### PR DESCRIPTION
**Improvements:**

1. Simplify dependency management thanks to utilization BOM
2. Allow to run Junit4 and Junit5 test together
3. Fix Wrong indentation in pom.xml  