### PR TITLE
Fix SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <!-- Fix dependency convergence [logback-classic vs junit] -->
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Fixing logging error
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

Dependencies Before fix
```log
[INFO] +- org.testcontainers:testcontainers:jar:1.18.0:compile
[INFO] |  +- junit:junit:jar:4.13.2:compile (scope not updated to compile)
[INFO] |  |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.36:compile (scope not updated to compile)

[INFO] \- ch.qos.logback:logback-classic:jar:1.4.7:provided
[INFO]    +- ch.qos.logback:logback-core:jar:1.4.7:provided
[INFO]    \- (org.slf4j:slf4j-api:jar:2.0.4:provided - omitted for conflict with 1.7.36)
```
Dependencies After fix
```log
[INFO] +- org.testcontainers:testcontainers:jar:1.18.0:compile
[INFO] |  +- junit:junit:jar:4.13.2:compile (scope not updated to compile)
[INFO] |  |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:2.0.4:compile (version managed from 1.7.36; scope not updated to compile)

[INFO] \- ch.qos.logback:logback-classic:jar:1.4.7:provided
[INFO]    +- ch.qos.logback:logback-core:jar:1.4.7:provided
[INFO]    \- (org.slf4j:slf4j-api:jar:2.0.4:provided - version managed from 2.0.4; omitted for duplicate)
```
