### PR TITLE
Disable JReleaser in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,23 +46,3 @@ jobs:
         run: mvn -ntp -B release:prepare release:perform
         env:
           GITHUB_TOKEN: ${{ github.token }}
-
-      # Create a GitHub Release
-      # TODO (oleg-nenashev): Consider switching to Release Drafter if there is not significant value except fancy changelog
-      # ... So far we do not plan to automate release announcements, and artifacts can be attached to the release via another step
-      - name: Run JReleaser
-        uses: jreleaser/release-action@v2
-        env:
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.version }}
-
-      # Persist JReleaser logs
-      - name: JReleaser release output
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: jreleaser-release
-          path: |
-            out/jreleaser/trace.log
-            out/jreleaser/output.properties
- 


### PR DESCRIPTION
Currently we use Release Drafter for changelogs, and we do not need to attach artifacts to the release since we use GitHub Packages. I will disable the code for now, and restore once we start using JReleaser for something else like announcements