### PR TITLE
Allow to override waiting strategy and waiting time

### DIFF
--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -77,6 +77,7 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     public WireMockContainer(String image, String version) {
         super(image + ":" + version);
         wireMockArgs = new StringBuilder();
+        setWaitStrategy(DEFAULT_WAITER);
     }
 
     /**
@@ -200,7 +201,6 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     protected void configure() {
         super.configure();
         withExposedPorts(PORT);
-        waitingFor(DEFAULT_WAITER);
         for (Stub stub : mappingStubs.values()) {
             withCopyToContainer(Transferable.of(stub.json), MAPPINGS_DIR + stub.name + ".json");
         }


### PR DESCRIPTION
## Motivation
default waiting strategy needs to be configured in constructor.
method `configure()`  is being executed right before container starts, so if we set  waiting strategy  here we will override any user specified waiters

## Before fix
```java
    public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
            .waitingFor(Wait.defaultWaitStrategy()) // ignored due to bug
            .withStartupTimeout(Duration.ofSeconds(11)) // ignored due to bug
```
## After fix
```java
   public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
            .waitingFor(Wait.defaultWaitStrategy()) // developer able to override strategy
            .withStartupTimeout(Duration.ofSeconds(11)) // developer able to override timeout
```
