### PR TITLE
Simplify Extentions api - Remove overhead with id

### DIFF
--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
@@ -44,9 +44,9 @@ class WireMockContainerExtensionTest {
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withStartupTimeout(Duration.ofSeconds(60))
             .withMapping("json-body-transformer", WireMockContainerExtensionTest.class, "json-body-transformer.json")
-            .withExtension("JSON Body Transformer",
+            .withExtension(
                     Collections.singleton("com.ninecookies.wiremock.extensions.JsonBodyTransformer"),
-                    Collections.singleton(Paths.get("target", "test-wiremock-extension", "wiremock-extensions-0.4.1-jar-with-dependencies.jar").toFile()));
+                    Paths.get("target", "test-wiremock-extension", "wiremock-extensions-0.4.1-jar-with-dependencies.jar").toFile());
 
     @Test
     void testJSONBodyTransformer() throws Exception {

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsCombinationTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsCombinationTest.java
@@ -25,7 +25,7 @@ import org.wiremock.integrations.testcontainers.testsupport.http.HttpResponse;
 import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
 
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,12 +42,9 @@ class WireMockContainerExtensionsCombinationTest {
     WireMockContainer wiremockServer = new WireMockContainer(WireMockContainer.WIREMOCK_2_LATEST)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withMapping("json-body-transformer", WireMockContainerExtensionsCombinationTest.class, "json-body-transformer.json")
-            .withExtension("Webhook",
-                    Collections.singleton("org.wiremock.webhooks.Webhooks"),
-                    Collections.singleton(Paths.get("target", "test-wiremock-extension", "wiremock-webhooks-extension-2.35.0.jar").toFile()))
-            .withExtension("JSON Body Transformer",
-                    Collections.singleton("com.ninecookies.wiremock.extensions.JsonBodyTransformer"),
-                    Collections.singleton(Paths.get("target", "test-wiremock-extension", "wiremock-extensions-0.4.1-jar-with-dependencies.jar").toFile()));
+            .withExtension(
+                    Arrays.asList("org.wiremock.webhooks.Webhooks", "com.ninecookies.wiremock.extensions.JsonBodyTransformer"),
+                    Paths.get("target", "test-wiremock-extension"));
 
     @Test
     void testJSONBodyTransformer() throws Exception {

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest.java
@@ -60,7 +60,7 @@ class WireMockContainerExtensionsWebhookTest {
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withCliArg("--global-response-templating")
             .withMapping("webhook-callback-template", WireMockContainerExtensionsWebhookTest.class, "webhook-callback-template.json")
-            .withExtension("Webhook",
+            .withExtension(
                     Collections.singleton("org.wiremock.webhooks.Webhooks"),
                     Collections.singleton(Paths.get("target", "test-wiremock-extension", "wiremock-webhooks-extension-2.35.0.jar").toFile()))
             .withAccessToHost(true); // Force the host access mechanism


### PR DESCRIPTION
## Motivation

- Param `id` does not bring any benefits and looks redundant
- Store all `extensionJars` in a `LinkedHashSet` to preserve an order and keep only unique values
- Store all `extensionClassNames` in a `LinkedHashSet` to preserve an order and keep only unique value

