### PR TITLE
Reduce Code duplication in tests and make tests easier to read

### DIFF
--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
@@ -21,10 +21,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -55,15 +53,14 @@ public class WireMockContainerExtensionTest {
 
     @Test
     public void testJSONBodyTransformer() throws Exception {
-        final HttpClient client = HttpClient.newBuilder().build();
-        final HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(wiremockServer.getUrl("/json-body-transformer")))
-                .timeout(Duration.ofSeconds(10))
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString("{\"name\":\"John Doe\"}")).build();
+        // given
+        String url = wiremockServer.getUrl("/json-body-transformer");
+        String body = "{\"name\":\"John Doe\"}";
 
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().post(url, body);
 
+        // then
         assertThat(response.body())
                 .as("Wrong response body")
                 .contains("Hello, John Doe!");

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsCombinationTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsCombinationTest.java
@@ -21,13 +21,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Paths;
-import java.time.Duration;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,15 +54,14 @@ public class WireMockContainerExtensionsCombinationTest {
 
     @Test
     public void testJSONBodyTransformer() throws Exception {
-        final HttpClient client = HttpClient.newBuilder().build();
-        final HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(wiremockServer.getUrl("/json-body-transformer")))
-                .timeout(Duration.ofSeconds(10))
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString("{\"name\":\"John Doe\"}")).build();
+        // given
+        String url = wiremockServer.getUrl("/json-body-transformer");
+        String body = "{\"name\":\"John Doe\"}";
 
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().post(url, body);
 
+        // then
         assertThat(response.body())
                 .as("Wrong response body")
                 .contains("Hello, John Doe!");

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
@@ -2,16 +2,13 @@ package org.wiremock.integrations.testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
 
 @Testcontainers
 public class WireMockContainerJUnit5Test {
@@ -30,15 +27,13 @@ public class WireMockContainerJUnit5Test {
           "/hello"
   })
   public void helloWorld(String path) throws Exception {
-    final HttpClient client = HttpClient.newBuilder().build();
-    final HttpRequest request = HttpRequest.newBuilder()
-        .uri(URI.create(wiremockServer.getUrl(path)))
-        .timeout(Duration.ofSeconds(10))
-        .header("Content-Type", "application/json")
-        .GET().build();
+    // given
+    String url = wiremockServer.getUrl(path);
 
-    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    // when
+    HttpResponse<String> response = TestHttpClient.newInstance().get(url);
 
+    // then
     assertThat(response.body())
         .as("Wrong response body")
         .contains("Hello, world!");
@@ -46,20 +41,13 @@ public class WireMockContainerJUnit5Test {
 
   @Test
   public void helloWorldFromFile() throws Exception {
-    final HttpClient client = HttpClient.newBuilder()
-        .version(HttpClient.Version.HTTP_1_1)
-        .build();
+    // given
+    String url = wiremockServer.getUrl("/hello-from-file");
 
-    HttpRequest request = HttpRequest.newBuilder()
-        .uri(URI.create(wiremockServer.getUrl("/hello-from-file")))
-        .timeout(Duration.ofSeconds(10))
-        .header("Content-Type", "application/json")
-        .GET()
-        .build();
+    // when
+    HttpResponse<String> response = TestHttpClient.newInstance().get(url);
 
-    HttpResponse<String> response =
-        client.send(request, HttpResponse.BodyHandlers.ofString());
-
+    // then
     assertThat(response.body())
         .as("Wrong response body")
         .contains("Hello, world!");

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerTest.java
@@ -17,12 +17,9 @@ package org.wiremock.integrations.testcontainers;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,15 +33,13 @@ public class WireMockContainerTest {
 
     @Test
     public void helloWorld() throws Exception {
-        final HttpClient client = HttpClient.newBuilder().build();
-        final HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(wiremockServer.getUrl("/hello")))
-                .timeout(Duration.ofSeconds(10))
-                .header("Content-Type", "application/json")
-                .GET().build();
+        // given
+        String url = wiremockServer.getUrl("/hello");
 
-        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().get(url);
 
+        // then
         assertThat(response.body())
                 .as("Wrong response body")
                 .contains("Hello, world!");
@@ -52,15 +47,13 @@ public class WireMockContainerTest {
 
     @Test
     public void helloWorldWithoutLeadingSlashInPath() throws Exception {
-        final HttpClient client = HttpClient.newBuilder().build();
-        final HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(wiremockServer.getUrl("hello")))
-                .timeout(Duration.ofSeconds(10))
-                .header("Content-Type", "application/json")
-                .GET().build();
+        // given
+        String url = wiremockServer.getUrl("hello");
 
-        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().get(url);
 
+        // then
         assertThat(response.body())
                 .as("Wrong response body")
                 .contains("Hello, world!");
@@ -68,16 +61,13 @@ public class WireMockContainerTest {
 
     @Test
     public void helloWorldFromFile() throws Exception {
-        final HttpClient client = HttpClient.newBuilder().build();
-        final HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(wiremockServer.getUrl("/hello-from-file")))
-                .timeout(Duration.ofSeconds(10))
-                .header("Content-Type", "application/json")
-                .GET().build();
+        // given
+        String url = wiremockServer.getUrl("/hello-from-file");
 
-        final HttpResponse<String> response =
-                client.send(request, HttpResponse.BodyHandlers.ofString());
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().get(url);
 
+        // then
         assertThat(response.body())
                 .as("Wrong response body")
                 .contains("Hello, world!");

--- a/src/test/java/org/wiremock/integrations/testcontainers/testsupport/http/TestHttpClient.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/testsupport/http/TestHttpClient.java
@@ -1,0 +1,46 @@
+package org.wiremock.integrations.testcontainers.testsupport.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public final class TestHttpClient {
+    private final HttpClient client;
+
+    private TestHttpClient(HttpClient.Version version) {
+        client = HttpClient.newBuilder().version(version).build();
+    }
+
+    public static TestHttpClient newInstance() {
+        return new TestHttpClient(HttpClient.Version.HTTP_1_1);
+    }
+
+    public HttpResponse<String> send(HttpRequest request) throws IOException, InterruptedException {
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    public HttpResponse<String> get(String uri) throws IOException, InterruptedException {
+        HttpRequest request = newRequestBuilder()
+                .uri(URI.create(uri))
+                .GET()
+                .build();
+        return send(request);
+    }
+
+    public HttpResponse<String> post(String uri, String body) throws IOException, InterruptedException {
+        HttpRequest request = newRequestBuilder()
+                .uri(URI.create(uri))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        return send(request);
+    }
+
+    private static HttpRequest.Builder newRequestBuilder() {
+        return HttpRequest.newBuilder()
+                .timeout(Duration.ofSeconds(10));
+    }
+}


### PR DESCRIPTION
## Description
In every test method we have duplicated code block
```java
final HttpClient client = HttpClient.newBuilder().build();
final HttpRequest request = HttpRequest.newBuilder()
    .uri(URI.create(wiremockServer.getUrl("/json-body-transformer")))
    .timeout(Duration.ofSeconds(10))
    .header("Content-Type", "application/json")
    .POST(HttpRequest.BodyPublishers.ofString("{\"name\":\"John Doe\"}")).build();
```

This code block and similar once were extracted into testsupport utility class `TestHttpClient`
Result test you can see bellow:

```java
// given
String url = wiremockServer.getUrl("/json-body-transformer");
String body = "{\"name\":\"John Doe\"}";

// when
HttpResponse<String> response = TestHttpClient.newInstance().post(url, body);

// then
assertThat(response.body())
        .as("Wrong response body")
        .contains("Hello, John Doe!");
```

## References

N/A

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
