### PR TITLE
Webhook test and Testcontainers networking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <testcontainers.version>1.18.1</testcontainers.version>
     <junit.version>5.9.3</junit.version>
     <assertj.version>3.24.2</assertj.version>
+    <awaitility.version>4.2.0</awaitility.version>
     <project.scm.id>github</project.scm.id>
   </properties>
 
@@ -85,6 +86,12 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 WireMock Inc, Oleg Nenashev and all project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.integrations.testcontainers;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpServer;
+
+import java.net.http.HttpResponse;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+/**
+ * Tests the WireMock Webhook extension and TestContainers Networking
+ * For this type of tests we should use following steps:
+ * <p>
+ * Use {@link GenericContainer#withAccessToHost(boolean)} to force the host access mechanism
+ * <p>
+ * Use {@link Testcontainers#exposeHostPorts(int...)} to expose host machine ports to containers
+ * <p>
+ * Use {@link GenericContainer#INTERNAL_HOST_HOSTNAME} to calculate hostname for callback
+ *
+ * @see <a href="https://www.testcontainers.org/features/networking/">Testcontainers Networking</a>
+ */
+public class WireMockContainerExtensionsWebhookTest {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(WireMockContainerExtensionsWebhookTest.class);
+    public static final String WIREMOCK_PATH = "/wiremock/callback-trigger";
+    public static final String APPLICATION_PATH = "/application/callback-receiver";
+
+
+    public TestHttpServer applicationServer = TestHttpServer.newInstance();
+    @Rule
+    public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+            .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+            .withCliArg("--global-response-templating")
+            .withMapping("webhook-callback-template", WireMockContainerExtensionsWebhookTest.class, "webhook-callback-template.json")
+            .withExtension("Webhook",
+                    Collections.singleton("org.wiremock.webhooks.Webhooks"),
+                    Collections.singleton(Paths.get("target", "test-wiremock-extension", "wiremock-webhooks-extension-2.35.0.jar").toFile()))
+            .withAccessToHost(true); // Force the host access mechanism
+
+
+    @Test
+    public void callbackUsingJsonStub() throws Exception {
+        // given
+        Testcontainers.exposeHostPorts(applicationServer.getPort()); // Exposing host ports to the container
+
+        String wiremockUrl = wiremockServer.getUrl(WIREMOCK_PATH);
+        String applicationCallbackUrl = String.format("http://%s:%d%s", GenericContainer.INTERNAL_HOST_HOSTNAME, applicationServer.getPort(), APPLICATION_PATH);
+
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().post(
+                wiremockUrl,
+                "{\"callbackMethod\": \"PUT\", \"callbackUrl\": \"" + applicationCallbackUrl + "\"}"
+        );
+
+        // then
+        assertThat(response).as("Wiremock Response").isNotNull().satisfies(it -> {
+            assertThat(it.statusCode()).as("Wiremock Response Status").isEqualTo(200);
+            assertThat(it.body()).as("Wiremock Response Body")
+                    .contains("Please wait callback")
+                    .contains("PUT")
+                    .contains(applicationCallbackUrl);
+        });
+
+        await().atMost(Duration.ofMillis(5000)).untilAsserted(() -> {
+            assertThat(applicationServer.getRecordedRequests()).as("Received Callback")
+                    .hasSize(1)
+                    .first().usingRecursiveComparison()
+                    .isEqualTo(new TestHttpServer.RecordedRequest("PUT", APPLICATION_PATH, "Async processing Finished"));
+        });
+    }
+
+}

--- a/src/test/java/org/wiremock/integrations/testcontainers/testsupport/http/TestHttpServer.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/testsupport/http/TestHttpServer.java
@@ -1,0 +1,99 @@
+package org.wiremock.integrations.testcontainers.testsupport.http;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestHttpServer {
+    private final HttpServer server;
+    private final AllRequestsRecorder handler;
+
+    public static TestHttpServer newInstance() {
+        try {
+            return new TestHttpServer(0);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to start Test Http Server", e);
+        }
+    }
+
+    private TestHttpServer(int port) throws IOException {
+        // handlers
+        handler = new AllRequestsRecorder();
+        // server
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/", handler);
+        server.start();
+    }
+
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    public List<RecordedRequest> getRecordedRequests() {
+        return handler.getRecordedRequests();
+    }
+
+
+    private static final class AllRequestsRecorder implements HttpHandler {
+
+        private final List<RecordedRequest> recordedRequests = new ArrayList<>();
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String method = exchange.getRequestMethod();
+            String path = exchange.getRequestURI().getPath();
+            String body = exchange.getRequestBody().available() > 0
+                    ? new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8)
+                    : null;
+
+            recordedRequests.add(new RecordedRequest(method, path, body));
+
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        }
+
+        public List<RecordedRequest> getRecordedRequests() {
+            return recordedRequests;
+        }
+    }
+
+    public static final class RecordedRequest {
+        private final String method;
+        private final String path;
+        private final String body;
+
+        public RecordedRequest(String method, String path, String body) {
+            this.method = method;
+            this.path = path;
+            this.body = body;
+        }
+
+        public String getMethod() {
+            return method;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        @Override
+        public String toString() {
+            return "RecordedRequest{" +
+                    "method='" + method + '\'' +
+                    ", path='" + path + '\'' +
+                    ", body='" + body + '\'' +
+                    '}';
+        }
+
+    }
+}

--- a/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest/webhook-callback-template.json
+++ b/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest/webhook-callback-template.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/wiremock/callback-trigger"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Please wait callback",
+      "method": "{{jsonPath request.body '$.callbackMethod'}}",
+      "url": "{{jsonPath request.body '$.callbackUrl'}}"
+    }
+  },
+  "postServeActions": [
+    {
+      "name": "webhook",
+      "parameters": {
+        "method": "{{jsonPath originalRequest.body '$.callbackMethod'}}",
+        "url": "{{jsonPath originalRequest.body '$.callbackUrl'}}",
+        "body": "Async processing Finished",
+        "delay": {
+          "type": "fixed",
+          "milliseconds": 1000
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description
When we work with Webhook callbacks, Testcontainers(Docker) brings additional complexity related to networking, because wiremock that inside docker needs to make request to host machine. This requires additional configuration 

That is why i decided to add Tests that verify it and could be used as an example in documentation (in future) 

## Links

https://www.testcontainers.org/features/networking/

## References

N/A

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
