### PR TITLE
Disable WireMock banner in the CLI output by default 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,6 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>5.3.1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.3.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -28,7 +28,12 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -74,7 +74,16 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         wireMockArgs = new StringBuilder();
         setWaitStrategy(DEFAULT_WAITER);
     }
-
+    
+    /**
+     * Enables the banner when starting WireMock container.
+     * @return this instance
+     */
+    public WireMockContainer withBanner() {
+        isBannerDisabled = false;
+        return this;
+    }
+    
     /**
      * Adds CLI argument to the WireMock call.
      * @param arg Argument
@@ -82,9 +91,6 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      */
     public WireMockContainer withCliArg(String arg) {
         //TODO: Switch to framework with proper CLI escaping
-        if (arg.contains("--verbose")) {
-            isBannerDisabled = false;
-        }
         wireMockArgs.append(' ').append(arg);
         return this;
     }
@@ -250,5 +256,4 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
             this.id = id;
         }
     }
-
 }

--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -74,9 +74,18 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         wireMockArgs = new StringBuilder();
         setWaitStrategy(DEFAULT_WAITER);
     }
-    
+
     /**
-     * Enables the banner when starting WireMock container.
+     * Disables the banner when starting the WireMock container.
+     * @return this instance
+     */
+    public WireMockContainer withoutBanner() {
+        isBannerDisabled = true;
+        return this;
+    }
+
+    /**
+     * Enable the banner when starting the WireMock container.
      * @return this instance
      */
     public WireMockContainer withBanner() {

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
@@ -1,55 +1,83 @@
 package org.wiremock.integrations.testcontainers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
 
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 @Testcontainers
 public class WireMockContainerJUnit5Test {
 
-  @Container
-  public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
-      .withMapping("hello", WireMockContainerTest.class, "hello-world.json")
-      .withMapping("hello-resource", WireMockContainerTest.class, "hello-world-resource.json")
-      .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class,
-          "hello-world-resource-response.xml");
+    @Container
+    public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+            .withMapping("hello", WireMockContainerTest.class, "hello-world.json")
+            .withMapping("hello-resource", WireMockContainerTest.class, "hello-world-resource.json")
+            .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class,
+                    "hello-world-resource-response.xml");
 
 
-  @ParameterizedTest
-  @ValueSource(strings = {
-          "hello",
-          "/hello"
-  })
-  public void helloWorld(String path) throws Exception {
-    // given
-    String url = wiremockServer.getUrl(path);
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "hello",
+            "/hello"
+    })
+    public void helloWorld(String path) throws Exception {
+        // given
+        String url = wiremockServer.getUrl(path);
 
-    // when
-    HttpResponse<String> response = TestHttpClient.newInstance().get(url);
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().get(url);
 
-    // then
-    assertThat(response.body())
-        .as("Wrong response body")
-        .contains("Hello, world!");
-  }
+        // then
+        assertThat(response.body())
+                .as("Wrong response body")
+                .contains("Hello, world!");
+    }
 
-  @Test
-  public void helloWorldFromFile() throws Exception {
-    // given
-    String url = wiremockServer.getUrl("/hello-from-file");
+    @Test
+    public void helloWorldFromFile() throws Exception {
+        // given
+        String url = wiremockServer.getUrl("/hello-from-file");
 
-    // when
-    HttpResponse<String> response = TestHttpClient.newInstance().get(url);
+        // when
+        HttpResponse<String> response = TestHttpClient.newInstance().get(url);
 
-    // then
-    assertThat(response.body())
-        .as("Wrong response body")
-        .contains("Hello, world!");
-  }
+        // then
+        assertThat(response.body())
+                .as("Wrong response body")
+                .contains("Hello, world!");
+    }
+
+    @Test
+    public void defaultBannerDisabled() {
+        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0"));
+
+        wireMockContainerSpy.configure();
+
+        verify(wireMockContainerSpy).withCliArg("--disable-banner");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "--verbose",
+            " --verbose ",
+            "--verbose --help"
+    })
+    public void showBannerWhenStartingVerbose(String verboseArg) {
+        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0"));
+        wireMockContainerSpy.withCliArg(verboseArg);
+
+        wireMockContainerSpy.configure();
+
+        verify(wireMockContainerSpy, times(0)).withCliArg("--disable-banner");
+    }
 }

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
@@ -56,28 +56,4 @@ public class WireMockContainerJUnit5Test {
                 .as("Wrong response body")
                 .contains("Hello, world!");
     }
-
-    @Test
-    public void defaultBannerDisabled() {
-        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0"));
-
-        wireMockContainerSpy.configure();
-
-        verify(wireMockContainerSpy).withCliArg("--disable-banner");
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "--verbose",
-            " --verbose ",
-            "--verbose --help"
-    })
-    public void showBannerWhenStartingVerbose(String verboseArg) {
-        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0"));
-        wireMockContainerSpy.withCliArg(verboseArg);
-
-        wireMockContainerSpy.configure();
-
-        verify(wireMockContainerSpy, times(0)).withCliArg("--disable-banner");
-    }
 }

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJUnit5Test.java
@@ -3,7 +3,6 @@ package org.wiremock.integrations.testcontainers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
@@ -11,8 +10,6 @@ import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
 import java.net.http.HttpResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @Testcontainers
 public class WireMockContainerJUnit5Test {

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerUnitTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerUnitTest.java
@@ -1,0 +1,28 @@
+package org.wiremock.integrations.testcontainers;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class WireMockContainerUnitTest {
+
+    @Test
+    public void defaultBannerDisabled() {
+        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0"));
+
+        wireMockContainerSpy.configure();
+
+        verify(wireMockContainerSpy).withCliArg("--disable-banner");
+    }
+
+    @Test
+    public void enableBanner() {
+        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0")).withBanner();
+
+        wireMockContainerSpy.configure();
+
+        verify(wireMockContainerSpy, times(0)).withCliArg("--disable-banner");
+    }
+}

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerUnitTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerUnitTest.java
@@ -21,11 +21,24 @@ public class WireMockContainerUnitTest {
 
     @Test
     public void enableBanner() {
-        WireMockContainer wireMockContainerSpy = new WireMockContainer("2.35.0").withBanner();
+        WireMockContainer wireMockContainerSpy = new WireMockContainer("2.35.0")
+                .withBanner();
         wireMockContainerSpy.configure();
 
         String[] startUpArgs = wireMockContainerSpy.getCommandParts();
 
         assertFalse(Arrays.asList(startUpArgs).contains("--disable-banner"));
+    }
+
+    @Test
+    public void disableBanner() {
+        WireMockContainer wireMockContainerSpy = new WireMockContainer("2.35.0")
+                .withBanner()
+                .withoutBanner();
+        wireMockContainerSpy.configure();
+
+        String[] startUpArgs = wireMockContainerSpy.getCommandParts();
+
+        assertTrue(Arrays.asList(startUpArgs).contains("--disable-banner"));
     }
 }

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerUnitTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerUnitTest.java
@@ -1,28 +1,31 @@
 package org.wiremock.integrations.testcontainers;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WireMockContainerUnitTest {
 
     @Test
-    public void defaultBannerDisabled() {
-        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0"));
+    public void bannerIsByDefaultDisabled() {
+        WireMockContainer wireMockContainer = new WireMockContainer("2.35.0");
+        wireMockContainer.configure();
 
-        wireMockContainerSpy.configure();
+        String[] startUpArgs = wireMockContainer.getCommandParts();
 
-        verify(wireMockContainerSpy).withCliArg("--disable-banner");
+        assertTrue(Arrays.asList(startUpArgs).contains("--disable-banner"));
     }
 
     @Test
     public void enableBanner() {
-        WireMockContainer wireMockContainerSpy = Mockito.spy(new WireMockContainer("2.35.0")).withBanner();
-
+        WireMockContainer wireMockContainerSpy = new WireMockContainer("2.35.0").withBanner();
         wireMockContainerSpy.configure();
 
-        verify(wireMockContainerSpy, times(0)).withCliArg("--disable-banner");
+        String[] startUpArgs = wireMockContainerSpy.getCommandParts();
+
+        assertFalse(Arrays.asList(startUpArgs).contains("--disable-banner"));
     }
 }


### PR DESCRIPTION
Now the container is running by default with the cli arg --disabled. When using the verbose flag, the banner is shown when starting. 
## References
Issue -> https://github.com/wiremock/wiremock-testcontainers-java/issues/31

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
