### PR TITLE
Align WireMockContainer constructor with the Testcontainers certification requirements

### DIFF
--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -20,6 +20,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.shaded.com.google.common.io.Resources;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
@@ -43,8 +44,11 @@ import java.util.stream.Stream;
  * but other images can be included too at your own risk.
  */
 public class WireMockContainer extends GenericContainer<WireMockContainer> {
-    private static final String DEFAULT_IMAGE_NAME = "wiremock/wiremock";
-    private static final String DEFAULT_TAG = "latest";
+
+    public static final String DEFAULT_IMAGE_NAME = "wiremock/wiremock";
+    public static final String DEFAULT_TAG = "2.35.0";
+    public static final DockerImageName DEFAULT =
+            DockerImageName.parse(DEFAULT_IMAGE_NAME + ":" + DEFAULT_TAG);
 
     private static final String MAPPINGS_DIR = "/home/wiremock/mappings/";
     private static final String FILES_DIR = "/home/wiremock/__files/";
@@ -61,16 +65,15 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     private final Map<String, Extension> extensions = new HashMap<>();
     private boolean isBannerDisabled = true;
 
-    public WireMockContainer() {
-        this(DEFAULT_TAG);
+    /**
+     * Create image from the specified full image name (repo, image, tag)
+     */
+    public WireMockContainer(String image) {
+        this(DockerImageName.parse(image));
     }
 
-    public WireMockContainer(String version) {
-        this(DEFAULT_IMAGE_NAME, version);
-    }
-
-    public WireMockContainer(String image, String version) {
-        super(image + ":" + version);
+    public WireMockContainer(DockerImageName dockerImage) {
+        super(dockerImage);
         wireMockArgs = new StringBuilder();
         setWaitStrategy(DEFAULT_WAITER);
     }

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerBannerTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerBannerTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class WireMockContainerBannerTest {
 
-    WireMockContainer wireMockContainer = new WireMockContainer("2.35.0");
+    WireMockContainer wireMockContainer = new WireMockContainer(WireMockContainer.DEFAULT);
 
     @Test
     void bannerIsByDefaultDisabled() {

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
@@ -40,7 +40,7 @@ class WireMockContainerExtensionTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(WireMockContainerExtensionTest.class);
 
     @Container
-    WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+    WireMockContainer wiremockServer = new WireMockContainer(WireMockContainer.DEFAULT)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withStartupTimeout(Duration.ofSeconds(60))
             .withMapping("json-body-transformer", WireMockContainerExtensionTest.class, "json-body-transformer.json")

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsCombinationTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsCombinationTest.java
@@ -39,7 +39,7 @@ class WireMockContainerExtensionsCombinationTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(WireMockContainerExtensionsCombinationTest.class);
 
     @Container
-    WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+    WireMockContainer wiremockServer = new WireMockContainer(WireMockContainer.DEFAULT)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withMapping("json-body-transformer", WireMockContainerExtensionsCombinationTest.class, "json-body-transformer.json")
             .withExtension("Webhook",

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionsWebhookTest.java
@@ -56,7 +56,7 @@ class WireMockContainerExtensionsWebhookTest {
 
     TestHttpServer applicationServer = TestHttpServer.newInstance();
     @Container
-    WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+    WireMockContainer wiremockServer = new WireMockContainer(WireMockContainer.DEFAULT)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withCliArg("--global-response-templating")
             .withMapping("webhook-callback-template", WireMockContainerExtensionsWebhookTest.class, "webhook-callback-template.json")

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJunit4Test.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJunit4Test.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class WireMockContainerJunit4Test {
 
     @Rule
-    public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+    public WireMockContainer wiremockServer = new WireMockContainer(WireMockContainer.DEFAULT)
             .withMapping("hello", WireMockContainerTest.class, "hello-world.json")
             .withMapping("hello-resource", WireMockContainerTest.class, "hello-world-resource.json")
             .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class, "hello-world-resource-response.xml");

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class WireMockContainerTest {
 
     @Container
-    WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+    WireMockContainer wiremockServer = new WireMockContainer(WireMockContainer.DEFAULT)
             .withMapping("hello", WireMockContainerTest.class, "hello-world.json")
             .withMapping("hello-resource", WireMockContainerTest.class, "hello-world-resource.json")
             .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class,


### PR DESCRIPTION
Aligns the module constructors with the Official image requirements. It is a breaking change that I am not particularly fond of, but following AtomicJar's certification reqiuirements

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
