### PR TITLE
Provide API for adding mapping stubs and files without IDs + Allow loading mappings from any classpath location + Deprecate `WireMockContainer#withMapping()`

### DIFF
--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -142,9 +142,42 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      * @param resourceJson Mapping definition file
      * @return this instance
      */
+    public WireMockContainer withMappingFromResource(String name, Class<?> resource, String resourceJson) {
+        return withMapping(name, resource.getSimpleName() + "/" + resourceJson);
+    }
+
+    /**
+     * @deprecated use {@link #withMappingFromResource(String, Class, String)}
+     */
+    @Deprecated
     public WireMockContainer withMapping(String name, Class<?> resource, String resourceJson) {
+        return withMappingFromResource(name, resource, resourceJson);
+    }
+
+    /**
+     * Loads mapping stub from the resource file
+     * @param name Name of the mapping stub
+     * @param resourceName Resource name and path
+     * @return this instance
+     */
+    public WireMockContainer withMappingFromResource(String name, String resourceName) {
         try {
-            URL url = Resources.getResource(resource, resource.getSimpleName() + "/" + resourceJson);
+            URL url = Resources.getResource(resourceName);
+            String text = Resources.toString(url, StandardCharsets.UTF_8);
+            return withMapping(name, text);
+        } catch (IOException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+
+    /**
+     * Loads mapping stub from the resource file
+     * @param name Name of the mapping stub
+     * @param url Resource file URL
+     * @return this instance
+     */
+    public WireMockContainer withMappingFromResource(String name, URL url) {
+        try {
             String text = Resources.toString(url, StandardCharsets.UTF_8);
             return withMapping(name, text);
         } catch (IOException ex) {

--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -124,6 +124,15 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     }
 
     /**
+     * Add mapping JSON file from its value
+     * @param json JSON sting
+     * @return This instance
+     */
+    public WireMockContainer withMappingFromJSON(String json) {
+        return withMapping(Integer.toString(json.hashCode()), json);
+    }
+
+    /**
      * Adds a JSON mapping stub to WireMock configuration
      * @param name Name of the mapping stub
      * @param json Configuration JSON
@@ -144,6 +153,17 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      */
     public WireMockContainer withMappingFromResource(String name, Class<?> resource, String resourceJson) {
         return withMapping(name, resource.getSimpleName() + "/" + resourceJson);
+    }
+
+    /**
+     * Loads mapping stub from the class resource
+     * @param resource Resource class. Name of the class will be appended to the resource path
+     * @param resourceJson Mapping definition file
+     * @return this instance
+     */
+    public WireMockContainer withMappingFromResource(Class<?> resource, String resourceJson) {
+        final String id = resource.getName() + "_" + resourceJson;
+        return withMapping(id, resource.getSimpleName() + "/" + resourceJson);
     }
 
     /**
@@ -172,6 +192,16 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
 
     /**
      * Loads mapping stub from the resource file
+     * @param resourceName Resource name and path
+     * @return this instance
+     */
+    public WireMockContainer withMappingFromResource(String resourceName) {
+        String id = resourceName.replace('/', '_');
+        return withMappingFromResource(id, resourceName);
+    }
+
+    /**
+     * Loads mapping stub from the resource file
      * @param name Name of the mapping stub
      * @param url Resource file URL
      * @return this instance
@@ -185,8 +215,25 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         }
     }
 
+    /**
+     * Adds file
+     * @param name ID to be used
+     * @param file File to add
+     * @return This instance
+     */
     public WireMockContainer withFile(String name, File file) {
         mappingFiles.put(name, MountableFile.forHostPath(file.getPath()));
+        // TODO: Prevent duplication
+        return this;
+    }
+
+    /**
+     * Adds file
+     * @param file File to add
+     * @return This instance
+     */
+    public WireMockContainer withFile(File file) {
+        mappingFiles.put(file.getName(), MountableFile.forHostPath(file.getPath()));
         // TODO: Prevent duplication
         return this;
     }
@@ -197,8 +244,19 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         return this;
     }
 
+    public WireMockContainer withFileFromResource(String classpathResource) {
+        String id = classpathResource.replace('/', '_');
+        // TODO: Prevent duplication
+        return withFileFromResource(id, classpathResource);
+    }
+
     public WireMockContainer withFileFromResource(String name, Class<?> resource, String filename) {
         return withFileFromResource(name, resource.getName().replace('.', '/') + "/" + filename);
+    }
+
+    public WireMockContainer withFileFromResource(Class<?> resource, String filename) {
+        String id = resource.getSimpleName() + "_" + filename;
+        return withFileFromResource(id, resource, filename);
     }
 
     /**

--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -156,11 +156,13 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      * Loads mapping stub from the class resource
      * @param name Name of the mapping stub
      * @param resource Resource class. Name of the class will be appended to the resource path
-     * @param resourceJson Mapping definition file
+     * @param resourceJson Reference to the mapping definition file, starting from the {@code resource} root
+     *                     (normally package)
      * @return this instance
      */
     public WireMockContainer withMappingFromResource(String name, Class<?> resource, String resourceJson) {
-        return withMapping(name, resource.getSimpleName() + "/" + resourceJson);
+        final URL url = Resources.getResource(resource, resourceJson);
+        return withMappingFromResource(name, url);
     }
 
     /**
@@ -171,15 +173,16 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      */
     public WireMockContainer withMappingFromResource(Class<?> resource, String resourceJson) {
         final String id = resource.getName() + "_" + resourceJson;
-        return withMapping(id, resource.getSimpleName() + "/" + resourceJson);
+        return withMappingFromResource(id, resource.getSimpleName() + "/" + resourceJson);
     }
 
     /**
-     * @deprecated use {@link #withMappingFromResource(String, Class, String)}
+     * @deprecated use {@link #withMappingFromResource(String, Class, String)}.
+     *                  Note that the new method scopes to the package, not to class
      */
     @Deprecated
     public WireMockContainer withMapping(String name, Class<?> resource, String resourceJson) {
-        return withMappingFromResource(name, resource, resourceJson);
+        return withMappingFromResource(name, resource, resource.getSimpleName() + "/" + resourceJson);
     }
 
     /**
@@ -189,14 +192,11 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      * @return this instance
      */
     public WireMockContainer withMappingFromResource(String name, String resourceName) {
-        try {
-            URL url = Resources.getResource(resourceName);
-            String text = Resources.toString(url, StandardCharsets.UTF_8);
-            return withMapping(name, text);
-        } catch (IOException ex) {
-            throw new IllegalArgumentException(ex);
-        }
+        final URL url = Resources.getResource(resourceName);
+        return withMappingFromResource(name, url);
     }
+
+
 
     /**
      * Loads mapping stub from the resource file

--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -129,7 +129,7 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      * @return This instance
      */
     public WireMockContainer withMappingFromJSON(String json) {
-        return withMapping(Integer.toString(json.hashCode()), json);
+        return withMappingFromJSON(Integer.toString(json.hashCode()), json);
     }
 
     /**
@@ -138,10 +138,18 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
      * @param json Configuration JSON
      * @return this instance
      */
-    public WireMockContainer withMapping(String name, String json) {
+    public WireMockContainer withMappingFromJSON(String name, String json) {
         mappingStubs.put(name, new Stub(name, json));
         // TODO: Prevent duplication
         return this;
+    }
+
+    /**
+     * @deprecated use {@link #withMappingFromJSON(String, String)}
+     */
+    @Deprecated
+    public WireMockContainer withMapping(String name, String json) {
+        return withMappingFromJSON(name, json);
     }
 
     /**


### PR DESCRIPTION
Simplifies API for #61,  and also simplifies the API for other calls, e.g. by excluding mandatory IDs as @bitxon mentioned for extensions. We try to infer IDs where possible. The extensions is coming in another PR


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
