### PR TITLE
Verify mappings status in WireMock test container on startup and fail by default when there're no mappings

### DIFF
--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerEmptyMapppingTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerEmptyMapppingTest.java
@@ -1,0 +1,19 @@
+package org.wiremock.integrations.testcontainers;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class WireMockContainerEmptyMapppingTest {
+
+    @Container
+    WireMockContainer wiremockServer = new WireMockContainer(WireMockContainer.WIREMOCK_2_LATEST)
+            .withIgnoreEmptyMappings(true);
+
+    @Test
+    public void shouldStartupWhenEmptyIsIgnored() {
+        // noop, all logic is inside the container instance
+    }
+
+}


### PR DESCRIPTION
This is an alternative to #69 for #28 that uses the Wait Strategy to verify the response and say the container is not ready if there are no mappings. Unfortunately it is not going help with #28, bacause there is no way to abort the wait loop from the predicate.

<!-- Please describe your pull request here. -->


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
