### PR TITLE
Add /health endpoint in waiting strategy

### DIFF
--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -50,6 +50,8 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     private static final String WIREMOCK_2_LATEST_TAG = "2.35.0";
     /*package*/ static final String WIREMOCK_2_MINIMUM_SUPPORTED_VERSION = "2.0.0";
 
+    static final String WIREMOCK_HEALTH_CHECK_SUPPORT_MINIMUM_VERSION = "3.0.0-1";
+
     public static final DockerImageName WIREMOCK_2_LATEST =
             DockerImageName.parse(OFFICIAL_IMAGE_NAME).withTag(WIREMOCK_2_LATEST_TAG);
 
@@ -59,6 +61,11 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     private static final String EXTENSIONS_DIR = "/var/wiremock/extensions/";
     private static final WaitStrategy DEFAULT_WAITER = Wait
             .forHttp("/__admin/mappings")
+            .withMethod("GET")
+            .forStatusCode(200);
+
+    private static final WaitStrategy HEALTH_CHECK_ENDPOINT_WAITER = Wait
+            .forHttp("/__admin/health")
             .withMethod("GET")
             .forStatusCode(200);
     private static final int PORT = 8080;
@@ -91,7 +98,13 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         }
 
         wireMockArgs = new StringBuilder();
-        setWaitStrategy(DEFAULT_WAITER);
+
+        if (version.isGreaterThanOrEqualTo(WIREMOCK_HEALTH_CHECK_SUPPORT_MINIMUM_VERSION)) {
+            setWaitStrategy(HEALTH_CHECK_ENDPOINT_WAITER);
+        }
+        else {
+            setWaitStrategy(DEFAULT_WAITER);
+        }
     }
 
     /**

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerWithWireMockVersionThreeTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerWithWireMockVersionThreeTest.java
@@ -1,0 +1,40 @@
+package org.wiremock.integrations.testcontainers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.wiremock.integrations.testcontainers.testsupport.http.HttpResponse;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+public class WireMockContainerWithWireMockVersionThreeTest
+{
+    @Container
+    WireMockContainer wiremockServer = new WireMockContainer("wiremock/wiremock:" + WireMockContainer.WIREMOCK_HEALTH_CHECK_SUPPORT_MINIMUM_VERSION)
+            .withMapping("hello", WireMockContainerTest.class, "hello-world.json")
+            .withMapping("hello-resource", WireMockContainerTest.class, "hello-world-resource.json")
+            .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class,
+                                  "hello-world-resource-response.xml");
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "hello",
+            "/hello"
+    })
+    void helloWorld(String path) throws Exception {
+        // given
+        String url = wiremockServer.getUrl(path);
+
+        // when
+        HttpResponse response = new TestHttpClient().get(url);
+
+        // then
+        assertThat(response.getBody())
+                .as("Wrong response body")
+                .contains("Hello, world!");
+    }
+}


### PR DESCRIPTION
As part of this PR, it has added /health endpoint as waiting strategy for docker images with minimum version 3.0.0-1. 

## References
Resolves => https://github.com/wiremock/wiremock-testcontainers-java/issues/28

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected

