### PR TITLE
Add Maven Central release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure Git user
+        run: |
+            git config user.email "actions@github.com"
+            git config user.name "GitHub Actions"
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -29,20 +34,29 @@ jobs:
           distribution: 'temurin'
           cache: maven
  
-      - name: Configure Git user
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
- 
       - name: Set Release Version
         id: vars
         shell: bash
         run: |
           echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          mvn -ntp -B versions:set -DnewVersion=${{ github.event.inputs.version }}-SNAPSHOT
+          mvn -ntp --batch-mode versions:set -DnewVersion=${{ github.event.inputs.version }}
           git diff-index --quiet HEAD || git commit -m "Releasing version ${{ github.event.inputs.version }}" pom.xml
         
       - name: Publish to GitHub Packages
-        run: mvn -ntp -B release:prepare release:perform
+        run: mvn -ntp --batch-mode clean deploy -Prelease
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Set up Java for publishing to Maven Central
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish to the Maven Central
+        run: mvn --batch-mode deploy -Prelease,mavencentral-release
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -213,4 +213,90 @@
       <url>https://maven.pkg.github.com/wiremock/wiremock-testcontainers-java</url>
     </repository>
   </distributionManagement>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <properties>
+          <version.maven-release-plugin>3.0.0-M7</version.maven-release-plugin>
+          <version.maven-gpg-plugin>3.0.1</version.maven-gpg-plugin>
+      </properties>
+      <build>
+          <pluginManagement>
+              <plugins>
+                  <plugin>
+                      <artifactId>maven-release-plugin</artifactId>
+                      <version>${version.maven-release-plugin}</version>
+                      <configuration>
+                          <tagNameFormat>@{project.version}</tagNameFormat>
+                      </configuration>
+                  </plugin>
+                  <!-- The key's name & passphrase are configured via GitHub's setup-java action. -->
+                  <plugin>
+                      <artifactId>maven-gpg-plugin</artifactId>
+                      <version>${version.maven-gpg-plugin}</version>
+                      <executions>
+                          <execution>
+                              <id>sign-artifacts</id>
+                              <phase>verify</phase>
+                              <goals>
+                                  <goal>sign</goal>
+                              </goals>
+                              <configuration>
+                                  <!-- This is required to make sure the plugin does not stop asking for -->
+                                  <!-- user input on the passphrase -->
+                                  <gpgArguments>
+                                      <arg>--pinentry-mode</arg>
+                                      <arg>loopback</arg>
+                                  </gpgArguments>
+                              </configuration>
+                          </execution>
+                      </executions>
+                  </plugin>
+              </plugins>
+          </pluginManagement>
+          <plugins>
+              <plugin>
+                  <artifactId>maven-gpg-plugin</artifactId>
+              </plugin>
+          </plugins>
+      </build>
+    </profile>
+        <profile>
+      <id>mavencentral-release</id>
+      <properties>
+          <version.nexus-staging-maven-plugin>1.6.13</version.nexus-staging-maven-plugin>
+      </properties>
+      <distributionManagement>
+        <repository>
+          <id>ossrh</id>
+          <name>Central Repository OSSRH</name>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+      <build>
+          <pluginManagement>
+              <plugins>
+                  <plugin>
+                      <groupId>org.sonatype.plugins</groupId>
+                      <artifactId>nexus-staging-maven-plugin</artifactId>
+                      <version>${version.nexus-staging-maven-plugin}</version>
+                      <extensions>true</extensions>
+                      <configuration>
+                          <serverId>ossrh</serverId>
+                          <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+                          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </pluginManagement>
+          <plugins>
+              <plugin>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+              </plugin>
+          </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
For #56 , most likely does not work but we will give it a try

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
