### PR TITLE
fix: Use addExposedPort instead of setExposedPort which overrides user configuration

### DIFF
--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -63,16 +63,18 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     private static final String FILES_DIR = "/home/wiremock/__files/";
 
     private static final String EXTENSIONS_DIR = "/var/wiremock/extensions/";
+    private static final int PORT = 8080;
     private static final WaitStrategy DEFAULT_WAITER = Wait
             .forHttp("/__admin/mappings")
             .withMethod("GET")
-            .forStatusCode(200);
+            .forStatusCode(200)
+            .forPort(PORT);
 
     private static final WaitStrategy HEALTH_CHECK_ENDPOINT_WAITER = Wait
             .forHttp("/__admin/health")
             .withMethod("GET")
-            .forStatusCode(200);
-    private static final int PORT = 8080;
+            .forStatusCode(200)
+            .forPort(PORT);
     private final StringBuilder wireMockArgs;
     private final Map<String, Stub> mappingStubs = new HashMap<>();
     private final Map<String, MountableFile> mappingFiles = new HashMap<>();
@@ -371,7 +373,7 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     @Override
     protected void configure() {
         super.configure();
-        withExposedPorts(PORT);
+        addExposedPorts(PORT);
         for (Stub stub : mappingStubs.values()) {
             withCopyToContainer(Transferable.of(stub.json), MAPPINGS_DIR + stub.name + ".json");
         }

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJunit4Test.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerJunit4Test.java
@@ -24,11 +24,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class WireMockContainerJunit4Test {
 
+    private static final int WIREMOCK_DEFAULT_PORT = 8080;
+    private static final int ADDITIONAL_MAPPED_PORT = 8443;
+
     @Rule
     public WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_DEFAULT_IMAGE)
             .withMapping("hello", WireMockContainerTest.class, "hello-world.json")
             .withMapping("hello-resource", WireMockContainerTest.class, "hello-world-resource.json")
-            .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class, "hello-world-resource-response.xml");
+            .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class, "hello-world-resource-response.xml")
+            .withExposedPorts(ADDITIONAL_MAPPED_PORT);
 
     @Test
     public void helloWorld() throws Exception {
@@ -70,5 +74,16 @@ public class WireMockContainerJunit4Test {
         assertThat(response.getBody())
                 .as("Wrong response body")
                 .contains("Hello, world!");
+    }
+
+    @Test
+    public void customPortsAreExposed() {
+        //given
+
+        //when
+
+        //then
+        assertThat(wiremockServer.getExposedPorts())
+                .contains(WIREMOCK_DEFAULT_PORT, ADDITIONAL_MAPPED_PORT);
     }
 }

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerTest.java
@@ -28,12 +28,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers(parallel = true)
 class WireMockContainerTest {
 
+    private static final int WIREMOCK_DEFAULT_PORT = 8080;
+    private static final int ADDITIONAL_MAPPED_PORT = 8443;
+
     @Container
     WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_DEFAULT_IMAGE)
             .withMapping("hello", WireMockContainerTest.class, "hello-world.json")
             .withMapping("hello-resource", WireMockContainerTest.class, "hello-world-resource.json")
             .withFileFromResource("hello-world-resource-response.xml", WireMockContainerTest.class,
-                    "hello-world-resource-response.xml");
+                    "hello-world-resource-response.xml")
+            .withExposedPorts(ADDITIONAL_MAPPED_PORT);
 
 
     @ParameterizedTest
@@ -66,5 +70,16 @@ class WireMockContainerTest {
         assertThat(response.getBody())
                 .as("Wrong response body")
                 .contains("Hello, world!");
+    }
+
+    @Test
+    void customPortsAreExposed() {
+        //given
+
+        //when
+
+        //then
+        assertThat(wiremockServer.getExposedPorts())
+                .contains(WIREMOCK_DEFAULT_PORT, ADDITIONAL_MAPPED_PORT);
     }
 }


### PR DESCRIPTION
…r configuration

Currently it is impossible to configure SSL, rather than go through all the hoops to add proper configuration for SSL I've applied this hotfix. By using addExposedPort we do not override the user configuration. Currently if I was to do the following:

```
  WireMockContainer wiremockServer = new WireMockContainer("wiremock/wiremock:2.35.0").withExposedPorts(8443);
```
This would never bind 8443 because when the container is started the configure also calls withExposedPorts, therefore overriding the user configured values.

This means we cannot configure SSL as we need a port for HTTP and HTTPS.

For testing I simply exposed an additional port to test that this would no longer override that port - this test if tried without the code change will fail. This confirms that the code is working as expected.

## References

#164 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ x ] The PR request is well described and justified, including the body and the references
- [ x ] The PR title represents the desired changelog entry
- [ x ] The repository's code style is followed (see the contributing guide)
- [ x ] Test coverage that demonstrates that the change works as expected
- [ x ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
