### PR TITLE
Load files and mappings from src/test/resources by default

### DIFF
--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerRootDirTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerRootDirTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2025 WireMock Inc, Oleg Nenashev and all project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.integrations.testcontainers;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.wiremock.integrations.testcontainers.testsupport.http.HttpResponse;
+import org.wiremock.integrations.testcontainers.testsupport.http.TestHttpClient;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers(parallel = true)
+class WireMockContainerRootDirTest {
+    @Container
+    WireMockContainer wiremockServer = new WireMockContainer(TestConfig.WIREMOCK_DEFAULT_IMAGE)
+            .withMapping("hello", WireMockContainerRootDirTest.class, "hello.json")
+            .withFileFromResource("file.json", WireMockContainerRootDirTest.class, "file.json")
+            .withRootDir(new File("src/test/resources/root-dir"));
+
+    @Test
+    void testThatLoadsMappingFromRootDirectory() throws Exception {
+        // given
+        String url = wiremockServer.getUrl("hello/root/dir");
+
+        // when
+        HttpResponse response = new TestHttpClient().get(url);
+
+        // then
+        assertThat(response.getBody())
+                .as("response body")
+                .contains("Hello root dir");
+    }
+
+    @Test
+    void testThatLoadsMappingFromNestedRootDirectory() throws Exception {
+        // given
+        String url = wiremockServer.getUrl("hello/nested/root/dir");
+
+        // when
+        HttpResponse response = new TestHttpClient().get(url);
+
+        // then
+        assertThat(response.getBody())
+                .as("response body")
+                .contains("Hello nested root dir");
+    }
+
+    @Test
+    void testThatServesFileFromRootDirectory() throws Exception {
+        // given
+        String url = wiremockServer.getUrl("root-dir-file.json");
+
+        // when
+        HttpResponse response = new TestHttpClient().get(url);
+
+        // then
+        assertThat(response.getBody())
+                .as("response body")
+                .isEqualTo("{ \"message\": \"file from root dir\" }");
+    }
+
+    @Test
+    void testThatServesNestedFileFromRootDirectory() throws Exception {
+        // given
+        String url = wiremockServer.getUrl("nested/root-dir-nested-file.json");
+
+        // when
+        HttpResponse response = new TestHttpClient().get(url);
+
+        // then
+        assertThat(response.getBody())
+                .as("response body")
+                .isEqualTo("{ \"message\": \"nested file from root dir\" }");
+    }
+
+    @Test
+    void testThatDirectMappingsAndFilesAreLoadedWithCustomRootDirEnabled() throws Exception {
+        // given
+        String url = wiremockServer.getUrl("/hello");
+
+        // when
+        HttpResponse response = new TestHttpClient().get(url);
+
+        // then
+        assertThat(response.getBody())
+                .as("Wrong response body")
+                .contains("file contents from direct mapping");
+    }
+
+    @Test
+    void testThatDirectMappingsAndFilesAreLoadedEvenWhenRootDirIsSpecified() throws Exception {
+        // given
+        String url = wiremockServer.getUrl("/hello");
+
+        // when
+        HttpResponse response = new TestHttpClient().get(url);
+
+        // then
+        assertThat(response.getBody())
+                .as("Wrong response body")
+                .contains("file contents from direct mapping");
+    }
+
+    @Test
+    void testThatMappingsAndFileAreLoadedFromDefaultRootDir() throws Exception {
+
+        try (WireMockContainer wmc = new WireMockContainer(TestConfig.WIREMOCK_DEFAULT_IMAGE)) {
+            wmc.start();
+
+            // given
+            String url = wmc.getUrl("/hello/default/root/dir");
+
+            // when
+            HttpResponse response = new TestHttpClient().get(url);
+
+            // then
+            assertThat(response.getBody())
+                    .as("Wrong response body")
+                    .contains("contents from default root dir file");
+        }
+    }
+
+    @Test
+    void testThatInvalidRootDirIsIgnored() throws Exception {
+
+        try (WireMockContainer wmc = new WireMockContainer(TestConfig.WIREMOCK_DEFAULT_IMAGE)
+                .withMapping("hello", WireMockContainerRootDirTest.class, "hello.json")
+                .withFileFromResource("file.json", WireMockContainerRootDirTest.class, "file.json")
+                .withRootDir(new File("invalid/root/dir"))) {
+            wmc.start();
+
+            // given
+            String url = wmc.getUrl("/hello");
+
+            // when
+            HttpResponse response = new TestHttpClient().get(url);
+
+            // then
+            assertThat(response.getBody())
+                    .as("Wrong response body")
+                    .contains("file contents from direct mapping");
+        }
+    }
+
+    @Test
+    void testThatNullRootDirIsIgnored() throws Exception {
+
+        try (WireMockContainer wmc = new WireMockContainer(TestConfig.WIREMOCK_DEFAULT_IMAGE)
+                .withMapping("hello", WireMockContainerRootDirTest.class, "hello.json")
+                .withFileFromResource("file.json", WireMockContainerRootDirTest.class, "file.json")
+                .withRootDir(null)) {
+            wmc.start();
+
+            // given
+            String url = wmc.getUrl("/hello");
+
+            // when
+            HttpResponse response = new TestHttpClient().get(url);
+
+            // then
+            assertThat(response.getBody())
+                    .as("Wrong response body")
+                    .contains("file contents from direct mapping");
+        }
+    }
+
+}

--- a/src/test/resources/__files/default-root-dir-file.json
+++ b/src/test/resources/__files/default-root-dir-file.json
@@ -1,0 +1,1 @@
+{ "message": "contents from default root dir file" }

--- a/src/test/resources/mappings/hello-default-root-dir.json
+++ b/src/test/resources/mappings/hello-default-root-dir.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/hello/default/root/dir"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "default-root-dir-file.json"
+  }
+}

--- a/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerRootDirTest/file.json
+++ b/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerRootDirTest/file.json
@@ -1,0 +1,1 @@
+{ "message": "file contents from direct mapping" }

--- a/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerRootDirTest/hello.json
+++ b/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerRootDirTest/hello.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/hello"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "file.json"
+  }
+}

--- a/src/test/resources/root-dir/__files/nested/root-dir-nested-file.json
+++ b/src/test/resources/root-dir/__files/nested/root-dir-nested-file.json
@@ -1,0 +1,1 @@
+{ "message": "nested file from root dir" }

--- a/src/test/resources/root-dir/__files/root-dir-file.json
+++ b/src/test/resources/root-dir/__files/root-dir-file.json
@@ -1,0 +1,1 @@
+{ "message": "file from root dir" }

--- a/src/test/resources/root-dir/mappings/hello-root-dir.json
+++ b/src/test/resources/root-dir/mappings/hello-root-dir.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/hello/root/dir"
+  },
+  "response": {
+    "status": 200,
+    "body": "Hello root dir"
+  }
+}

--- a/src/test/resources/root-dir/mappings/nested/hello-nested-root-dir.json
+++ b/src/test/resources/root-dir/mappings/nested/hello-nested-root-dir.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/hello/nested/root/dir"
+  },
+  "response": {
+    "status": 200,
+    "body": "Hello nested root dir"
+  }
+}


### PR DESCRIPTION
This PR adds support for loading files and mappings from test resources directory.

By default, It will look into `src/test/resources/mappings` and `src/test/resources/__files` behaving very similarly to when `WireMockServer` is started programmatically. This path can be configured via `withRootDir(File file)`.



This addition simplifies the testing setup by providing an alternative to having to map all stub and file paths individually using `with...()` calls.

**Before:**

```
@Testcontainers
public class WireMockLoadsFileMappingsByDefaultTest {

    @Container
    private WireMockContainer server = new WireMockContainer("wiremock/wiremock:latest")
            .withFile(new File("src/test/resources/static-file-1.txt"))
            .withFile(new File("src/test/resources/static-file-2.txt"))
            // other files
            .withMappingFromResource("src/test/resources/mappings/simple-mapping-1.json")
            .withMappingFromResource("src/test/resources/mappings/simple-mapping-2.json")
            // other mappings
            ;
[...]
```

**After:**

Make sure all stubs and files are stored in the proper sub-directories and all the manual inclusions may be removed:

```
    @Container
    private WireMockContainer server = new WireMockContainer("wiremock/wiremock:latest");
```

Alternatively, one can choose a different path to load mappings/files from:

```
    @Container
    private WireMockContainer server = new WireMockContainer("wiremock/wiremock:latest")
            .withRootDir("src/integration-test/resources")
```


## References

* Closes #134 


## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
