### PR TITLE
Update the default WireMock 3 Docker image for tests to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please feel free to contribute the integration tests and compatibility layers!
 
 ### Test Frameworks
 
-Versions before `1.0-alpha-3` were tested with JUnit 4 and JUnit 5.
+Versions before `1.0-alpha-16` were tested with JUnit 4 and JUnit 5.
 Newer versions were updates to Testcontainers 2 and hence require JUnit 5.
 All JUnit 5 compatible test frameworks should work.
 

--- a/src/test/java/org/wiremock/integrations/testcontainers/TestConfig.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/TestConfig.java
@@ -5,7 +5,7 @@ import org.testcontainers.utility.DockerImageName;
 public class TestConfig {
 
     private static final String DEFAULT_TEST_TAG =
-            System.getProperty("wiremock.testcontainer.defaultTag", "3.5.4");
+            System.getProperty("wiremock.testcontainer.defaultTag", "3.13.2-3");
     private static final String WIREMOCK_2_TEST_TAG =
             System.getProperty("wiremock.testcontainer.wiremock2Tag", "2.35.1-1");
 


### PR DESCRIPTION
Just housekeeping, it still works