### PR TITLE
Switch to the s01.oss.sonatype.org compatibility layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,6 @@
           <name>Central Repository OSSRH</name>
           <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
-        <plugins>
       </distributionManagement>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -284,21 +284,30 @@
         <repository>
           <id>ossrh</id>
           <name>Central Repository OSSRH</name>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+          <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
+        <plugins>
       </distributionManagement>
       <build>
+        <pluginManagement>
+              <plugins>
+                  <plugin>
+                      <groupId>org.sonatype.plugins</groupId>
+                      <artifactId>nexus-staging-maven-plugin</artifactId>
+                      <version>${version.nexus-staging-maven-plugin}</version>
+                      <extensions>true</extensions>
+                      <configuration>
+                          <serverId>ossrh</serverId>
+                          <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+                          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </pluginManagement>
           <plugins>
               <plugin>
-                  <groupId>org.sonatype.central</groupId>
-                  <artifactId>central-publishing-maven-plugin</artifactId>
-                  <version>0.9.0</version>
-                  <extensions>true</extensions>
-                  <configuration>
-                      <publishingServerId>ossrh</publishingServerId>
-                      <autoPublish>true</autoPublish>
-                      <waitUntil>published</waitUntil>
-                  </configuration>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
               </plugin>
           </plugins>
       </build>


### PR DESCRIPTION
#239 will not work on the current group ID until the migration is completed